### PR TITLE
Add routing hint to Catalog.cshtml

### DIFF
--- a/src/Pages/Catalog.cshtml
+++ b/src/Pages/Catalog.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/Tool/Catalog"
 @using AdvantageTool.Utility
 @model CatalogModel
 @{


### PR DESCRIPTION
The Post for Deeplinks from Tool.cshtml.cs to ./Catalog seems to end up in the ToolModel itself instead of the CatalogModel

I noticed the remark that the LtiAdvantageTool code is out of date - but it still seems the best resource available to study LTI implementation.