### PR TITLE
Port PR #7 fixes: deep link JWT param + line item results query string

### DIFF
--- a/src/AdvantageTool/Pages/Catalog.cshtml.cs
+++ b/src/AdvantageTool/Pages/Catalog.cshtml.cs
@@ -75,7 +75,7 @@ public class CatalogModel(ApplicationDbContext context) : PageModel
         var creds = PemHelper.SigningCredentialsFromPem(platform!.PrivateKey, platform.KeyId);
         var jwtOut = new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(new JwtHeader(creds), response));
 
-        return AutoPost("id_token", jwtOut, LtiRequest.DeepLinkingSettings.DeepLinkReturnUrl);
+        return AutoPost("JWT", jwtOut, LtiRequest.DeepLinkingSettings.DeepLinkReturnUrl);
     }
 
     private static ContentResult AutoPost(string name, string value, string url)

--- a/src/AdvantageTool/Pages/Components/LineItems/LineItemsViewComponent.cs
+++ b/src/AdvantageTool/Pages/Components/LineItems/LineItemsViewComponent.cs
@@ -82,7 +82,8 @@ public class LineItemsViewComponent(AccessTokenService tokens, IHttpClientFactor
             http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(Constants.MediaTypes.ResultContainer));
             foreach (var li in model.LineItems)
             {
-                var url = li.AgsLineItem.Id!.TrimEnd('/') + "/results";
+                var lineItemUri = new Uri(li.AgsLineItem.Id!);
+                var url = $"{lineItemUri.GetLeftPart(UriPartial.Path).TrimEnd('/')}/results{lineItemUri.Query}";
                 var json = await http.GetStringAsync(url);
                 li.Results = JsonSerializer.Deserialize<ResultContainer>(json, JsonOptions);
             }


### PR DESCRIPTION
Ports the two still-relevant fixes from #7 (by @jmpease) onto the net10 layout. The other PR #7 commits became obsolete after the net10 rewrite (NuGet swap, `./Catalog` post path) or were already integrated (Catalog routing hint via a177fe6).

## Commits (authored by Jim Pease)
- `4721240` **Deep linking response uses `JWT` form param** — Per LTI 1.3 Deep Linking spec §5.1, the signed JWT must be sent as a form parameter named `JWT`, not `id_token`, on the auto-submit form to `deep_link_return_url`.
- `1f35eaf` **Preserve query string on line item results URL** — `TrimEnd('/') + "/results"` dropped any query parameters carried on the line item URL (e.g. filters, pagination). Switched to `Uri.GetLeftPart(UriPartial.Path)` + `Uri.Query` so they flow through.

## Why a new PR
PR #7's head branch lives on a fork without "Allow edits from maintainers", so #7 itself can't be rebased onto current master. PR #13 already merged the net10 rewrite, making #7 unmergeable. Closing #7 in favor of this PR; full credit for the fixes goes to @jmpease.

Closes #7