### PR TITLE
Port PR #8 features: AGS create/delete line item, submit score, custom params, deep link tool URL

### DIFF
--- a/src/AdvantageTool/Pages/Catalog.cshtml.cs
+++ b/src/AdvantageTool/Pages/Catalog.cshtml.cs
@@ -51,13 +51,15 @@ public class CatalogModel(ApplicationDbContext context) : PageModel
             DeploymentId = LtiRequest.DeploymentId,
         };
 
+        var platform = await context.GetPlatformByIssuerAsync(LtiRequest.Iss!);
+
         var contentItems = Activities
             .Where(a => a.Selected)
             .Select(a => (ContentItem)new LtiLinkItem
             {
                 Title = a.Title,
                 Text = a.Description,
-                Url = Url.Page("/Tool", null, null, Request.Scheme),
+                Url = Url.Page("/Tool", null, new { platformId = platform!.PlatformId }, Request.Scheme),
                 Custom = new Dictionary<string, string> { ["activity_id"] = a.Id.ToString() },
             })
             .ToArray();
@@ -71,7 +73,6 @@ public class CatalogModel(ApplicationDbContext context) : PageModel
         response.AddClaim(new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(DateTime.UtcNow.AddMinutes(5)).ToString()));
         response.AddClaim(new Claim(JwtRegisteredClaimNames.Nonce, Guid.NewGuid().ToString("N")));
 
-        var platform = await context.GetPlatformByIssuerAsync(LtiRequest.Iss!);
         var creds = PemHelper.SigningCredentialsFromPem(platform!.PrivateKey, platform.KeyId);
         var jwtOut = new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(new JwtHeader(creds), response));
 

--- a/src/AdvantageTool/Pages/Components/LineItems/Default.cshtml
+++ b/src/AdvantageTool/Pages/Components/LineItems/Default.cshtml
@@ -38,6 +38,11 @@
                                     <input type="hidden" name="lineItemUrl" value="@li.AgsLineItem.Id" />
                                     <button type="submit" class="btn btn-light btn-sm" title="Submit a random score for the launch user">Submit a score</button>
                                 </form>
+                                <form method="post" action="?handler=DeleteLineItem" class="d-inline ms-1">
+                                    <input type="hidden" name="id_token" value="@Model.IdToken" />
+                                    <input type="hidden" name="lineItemUrl" value="@li.AgsLineItem.Id" />
+                                    <button type="submit" class="btn btn-outline-danger btn-sm" title="Delete this line item">Delete</button>
+                                </form>
                             }
                             @if (li.Results is { Count: > 0 })
                             {

--- a/src/AdvantageTool/Pages/Components/LineItems/Default.cshtml
+++ b/src/AdvantageTool/Pages/Components/LineItems/Default.cshtml
@@ -31,6 +31,14 @@
                     {
                         <li>
                             <strong>@li.Header</strong>
+                            @if (!string.IsNullOrEmpty(li.AgsLineItem.Id))
+                            {
+                                <form method="post" action="?handler=PostScore" class="d-inline ms-2">
+                                    <input type="hidden" name="id_token" value="@Model.IdToken" />
+                                    <input type="hidden" name="lineItemUrl" value="@li.AgsLineItem.Id" />
+                                    <button type="submit" class="btn btn-light btn-sm" title="Submit a random score for the launch user">Submit a score</button>
+                                </form>
+                            }
                             @if (li.Results is { Count: > 0 })
                             {
                                 <ul>

--- a/src/AdvantageTool/Pages/Components/LineItems/Default.cshtml
+++ b/src/AdvantageTool/Pages/Components/LineItems/Default.cshtml
@@ -9,6 +9,16 @@
         }
         else
         {
+            @if (Model.LtiRequest?.AssignmentGradeServices?.LineItemsUrl is { Length: > 0 })
+            {
+                <form method="post" action="?handler=CreateLineItem" class="form-inline mb-3">
+                    <input type="hidden" name="id_token" value="@Model.IdToken" />
+                    <label class="me-2 mb-0">Resource Link ID</label>
+                    <input type="text" name="resource_link_id" value="@Model.LtiRequest.ResourceLink?.Id" class="form-control form-control-sm me-2" />
+                    <button type="submit" class="btn btn-light btn-sm">Add line item</button>
+                </form>
+            }
+
             <h5>Line items</h5>
             @if (Model.LineItems.Count == 0)
             {

--- a/src/AdvantageTool/Pages/Tool.cshtml
+++ b/src/AdvantageTool/Pages/Tool.cshtml
@@ -42,6 +42,22 @@
         </div>
     </div>
 
+    @if (Model.LtiRequest.Custom is { Count: > 0 })
+    {
+        <div class="card mb-3">
+            <div class="card-header">Custom parameters</div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    @foreach (var (k, v) in Model.LtiRequest.Custom.OrderBy(kv => kv.Key))
+                    {
+                        <dt class="col-sm-3">@k</dt>
+                        <dd class="col-sm-9">@v</dd>
+                    }
+                </dl>
+            </div>
+        </div>
+    }
+
     @if (Model.LtiRequest.AssignmentGradeServices is not null || Model.LtiRequest.NamesRoleService is not null)
     {
         @await Component.InvokeAsync("LineItems", Model.IdToken)

--- a/src/AdvantageTool/Pages/Tool.cshtml.cs
+++ b/src/AdvantageTool/Pages/Tool.cshtml.cs
@@ -1,7 +1,12 @@
 using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 using AdvantageTool.Data;
+using AdvantageTool.Services;
+using IdentityModel.Client;
 using LtiAdvantage;
+using LtiAdvantage.AssignmentGradeServices;
 using LtiAdvantage.Lti;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -13,10 +18,12 @@ namespace AdvantageTool.Pages;
 public class ToolModel(
     ApplicationDbContext context,
     StateDbContext state,
-    IHttpClientFactory httpClientFactory) : PageModel
+    IHttpClientFactory httpClientFactory,
+    AccessTokenService tokens) : PageModel
 {
     public string? Error { get; set; }
     public string? IdToken { get; set; }
+    public string? PlatformId { get; set; }
     public JwtHeader? JwtHeader { get; set; }
     public LtiResourceLinkRequest? LtiRequest { get; set; }
 
@@ -79,8 +86,65 @@ public class ToolModel(
             return AutoPost(Url.Page("/Catalog")!, new { IdToken = idToken });
 
         IdToken = idToken;
+        PlatformId = platformId;
         LtiRequest = new LtiResourceLinkRequest(jwt.Payload);
         return Page();
+    }
+
+    public async Task<IActionResult> OnPostCreateLineItemAsync(
+        [FromForm(Name = "id_token")] string? idToken,
+        [FromForm(Name = "resource_link_id")] string? resourceLinkId)
+    {
+        if (!RestoreLaunchState(idToken)) return Page();
+
+        var lineItemsUrl = LtiRequest!.AssignmentGradeServices?.LineItemsUrl;
+        if (string.IsNullOrEmpty(lineItemsUrl)) { Error = "AGS not present in launch."; return Page(); }
+
+        var http = await CreateAgsClientAsync(Constants.LtiScopes.Ags.LineItem, Constants.MediaTypes.LineItem);
+        if (http is null) return Page();
+
+        var lineItem = new LineItem
+        {
+            EndDateTime = DateTime.UtcNow.AddMonths(3),
+            Label = LtiRequest.ResourceLink?.Title ?? "Line item",
+            ResourceLinkId = string.IsNullOrEmpty(resourceLinkId) ? LtiRequest.ResourceLink?.Id : resourceLinkId,
+            ScoreMaximum = 100,
+            StartDateTime = DateTime.UtcNow,
+        };
+
+        try
+        {
+            var content = new StringContent(JsonSerializer.Serialize(lineItem), Encoding.UTF8, Constants.MediaTypes.LineItem);
+            using var response = await http.PostAsync(lineItemsUrl, content);
+            if (!response.IsSuccessStatusCode) Error = $"Create line item failed: {(int)response.StatusCode} {response.ReasonPhrase}";
+        }
+        catch (Exception e) { Error = e.Message; }
+
+        return Page();
+    }
+
+    private bool RestoreLaunchState(string? idToken)
+    {
+        if (string.IsNullOrEmpty(idToken)) { Error = "id_token missing"; return false; }
+        var handler = new JwtSecurityTokenHandler();
+        if (!handler.CanReadToken(idToken)) { Error = "Cannot read id_token"; return false; }
+        var jwt = handler.ReadJwtToken(idToken);
+        IdToken = idToken;
+        PlatformId = RouteData.Values["platformId"]?.ToString();
+        JwtHeader = jwt.Header;
+        LtiRequest = new LtiResourceLinkRequest(jwt.Payload);
+        return true;
+    }
+
+    private async Task<HttpClient?> CreateAgsClientAsync(string scope, string mediaType)
+    {
+        var token = await tokens.GetAccessTokenAsync(LtiRequest!.Iss!, scope);
+        if (token.IsError && token.Error != "Created") { Error = token.Error; return null; }
+
+        var http = httpClientFactory.CreateClient();
+        http.SetBearerToken(token.AccessToken!);
+        http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(mediaType));
+        return http;
     }
 
     private ContentResult AutoPost(string url, object values)

--- a/src/AdvantageTool/Pages/Tool.cshtml.cs
+++ b/src/AdvantageTool/Pages/Tool.cshtml.cs
@@ -123,6 +123,26 @@ public class ToolModel(
         return Page();
     }
 
+    public async Task<IActionResult> OnPostDeleteLineItemAsync(
+        [FromForm(Name = "id_token")] string? idToken,
+        [FromForm(Name = "lineItemUrl")] string? lineItemUrl)
+    {
+        if (!RestoreLaunchState(idToken)) return Page();
+        if (string.IsNullOrEmpty(lineItemUrl)) { Error = "lineItemUrl missing"; return Page(); }
+
+        var http = await CreateAgsClientAsync(Constants.LtiScopes.Ags.LineItem, Constants.MediaTypes.LineItem);
+        if (http is null) return Page();
+
+        try
+        {
+            using var response = await http.DeleteAsync(lineItemUrl);
+            if (!response.IsSuccessStatusCode) Error = $"Delete line item failed: {(int)response.StatusCode} {response.ReasonPhrase}";
+        }
+        catch (Exception e) { Error = e.Message; }
+
+        return Page();
+    }
+
     public async Task<IActionResult> OnPostPostScoreAsync(
         [FromForm(Name = "id_token")] string? idToken,
         [FromForm(Name = "lineItemUrl")] string? lineItemUrl)

--- a/src/AdvantageTool/Pages/Tool.cshtml.cs
+++ b/src/AdvantageTool/Pages/Tool.cshtml.cs
@@ -123,6 +123,39 @@ public class ToolModel(
         return Page();
     }
 
+    public async Task<IActionResult> OnPostPostScoreAsync(
+        [FromForm(Name = "id_token")] string? idToken,
+        [FromForm(Name = "lineItemUrl")] string? lineItemUrl)
+    {
+        if (!RestoreLaunchState(idToken)) return Page();
+        if (string.IsNullOrEmpty(lineItemUrl)) { Error = "lineItemUrl missing"; return Page(); }
+
+        var http = await CreateAgsClientAsync(Constants.LtiScopes.Ags.Score, Constants.MediaTypes.Score);
+        if (http is null) return Page();
+
+        var score = new Score
+        {
+            ActivityProgress = ActivityProgress.Completed,
+            GradingProgress = GradingProgress.FullyGraded,
+            ScoreGiven = Math.Round(Random.Shared.NextDouble() * 100, 2),
+            ScoreMaximum = 100,
+            TimeStamp = DateTime.UtcNow,
+            UserId = LtiRequest!.UserId!,
+        };
+        if (score.ScoreGiven > 75) score.Comment = "Good job!";
+
+        try
+        {
+            var scoresUrl = $"{lineItemUrl.TrimEnd('/')}/scores";
+            var content = new StringContent(JsonSerializer.Serialize(score), Encoding.UTF8, Constants.MediaTypes.Score);
+            using var response = await http.PostAsync(scoresUrl, content);
+            if (!response.IsSuccessStatusCode) Error = $"Submit score failed: {(int)response.StatusCode} {response.ReasonPhrase}";
+        }
+        catch (Exception e) { Error = e.Message; }
+
+        return Page();
+    }
+
     private bool RestoreLaunchState(string? idToken)
     {
         if (string.IsNullOrEmpty(idToken)) { Error = "id_token missing"; return false; }


### PR DESCRIPTION
Ports the still-relevant features from #8 (closed without merge — fork deleted, project rewritten on net10) onto the current layout. Each commit preserves the original author.

## What's ported
- **edac0c3** Tom Mooney — Generate correct Tool URL with `platformId` in deep-link assignments (PR #8 `cfd3565`). The `/Tool/{platformId}` route otherwise wouldn't match LMS-launched URLs.
- **4871c3f** Tom Mooney — Display custom parameters from the LTI launch claim (PR #8 `e3cb912`).
- **8555dd5** Tom Mooney + Andy Miller — `OnPostCreateLineItemAsync` handler + form on the LineItems component (PR #8 `0112447` Andy, `ba1cfae` Tom). Defaults `resource_link_id` to the launch's resource link but lets the user override it. Also injects `AccessTokenService` into `ToolModel` and adds two helpers (`RestoreLaunchState`, `CreateAgsClientAsync`) reused by the next two commits.
- **f7a6a3d** Tom Mooney — `OnPostPostScoreAsync` handler + per-line-item 'Submit a score' button (PR #8 `4a24e40`). POSTs a fully-graded random score (with 'Good job!' if > 75) to `<lineItemUrl>/scores`.
- **0c31964** Tom Mooney — `OnPostDeleteLineItemAsync` handler + per-line-item Delete button (PR #8 `bac40f9`).

## What was intentionally dropped
- **Show results / line items / members on load** — already covered by the LineItems view component in master.
- **Null-ref guards on `Platform.Name` etc.** — net10 templates already use `?.` everywhere.
- **NuGet vs project-reference / submodule wiring** — obsolete; `LtiAdvantage 3.0.0` is consumed via NuGet.
- **JWT form param + `./Catalog` redirect** — JWT param already merged in #14; redirect now uses `Url.Page(\"/Catalog\")`.
- **PowerShell startup script** (Will Wolff-Myren) — dev convenience, easy to add later if wanted.
- **Allow invalid TLS certs in HttpClient** — security regression, deliberately not ported.

## Verification
- `dotnet build` clean (warnings only from NuGet feed-vulnerability lookup).
- `dotnet run` boots the app, home page returns HTTP 200, EF migrations run, DI graph resolves with the new `AccessTokenService` injection on `ToolModel`.
- Functional verification of the AGS handlers requires a live LTI platform launch and was **not** performed locally; behavior should match the original PR #8 implementations.